### PR TITLE
Add odometer signal (W204, 2007-2014)

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -1,4 +1,7 @@
 { "commands": [
-
+{ "hdr": "60A", "rax": "481", "cmd": {"22": "0001"}, "freq": 0.5, "dbgfilter": { "from": 2007, "to": 2014 },
+  "signals": [
+    {"id": "C_CLASS_ODO", "path": "Trips", "fmt": { "len": 24, "max": 16777215, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
+  ]}
 ]
 }

--- a/tests/test_cases/2007/commands/60A.481.220001.yaml
+++ b/tests/test_cases/2007/commands/60A.481.220001.yaml
@@ -1,0 +1,5 @@
+command_id: 60A.481.220001
+test_cases:
+- expected_values:
+    C_CLASS_ODO: 213607
+  response: "48106620001034267"


### PR DESCRIPTION
Captured from the original diagnostic tool on a 2007 C-Class (W204): the instrument cluster answers UDS ReadDataByIdentifier on header 60A / response 481, DID 0001. Value is a 24-bit big-endian km count. Verified across two readings: 0x034261 -> 213601 km, then 0x034267 -> 213607 km. W204 exposes no standard odometer (PID 01A6 absent); this is the manufacturer route.

Includes a response test case (0x034267 -> 213607 km).